### PR TITLE
Disable client profile updates

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -286,6 +286,12 @@ class  EndUser extends AuthenticatedUser {
         return $cached;
     }
 
+    function isAuthenticatingWithLdap() {
+        $acct = $this->getAccount();
+
+        return ('ldap.client' === $acct->get('backend'));
+    }
+
     private function getStats() {
 
         $where = ' WHERE ticket.user_id = '.db_input($this->getId())

--- a/include/client/header.inc.php
+++ b/include/client/header.inc.php
@@ -63,7 +63,13 @@ if (($lang = Internationalization::getCurrentLanguage())
                     && !$thisclient->isGuest()) {
                  echo Format::htmlchars($thisclient->getName()).'&nbsp;|';
                  ?>
+             <?php
+                if (!$thisclient->isAuthenticatingWithLdap()) {
+                 ?>
                 <a href="<?php echo ROOT_PATH; ?>profile.php"><?php echo __('Profile'); ?></a> |
+             <?php
+                }
+                 ?>
                 <a href="<?php echo ROOT_PATH; ?>tickets.php"><?php echo sprintf(__('Tickets <b>(%d)</b>'), $thisclient->getNumTickets()); ?></a> -
                 <a href="<?php echo $signout_url; ?>"><?php echo __('Sign Out'); ?></a>
             <?php

--- a/profile.php
+++ b/profile.php
@@ -21,6 +21,10 @@ require 'secure.inc.php';
 require_once 'class.user.php';
 $user = User::lookup($thisclient->getId());
 
+if ($thisclient->isAuthenticatingWithLdap()) {
+    die('Access denied');
+}
+
 if ($user && $_POST) {
     $errors = array();
     if ($acct = $thisclient->getAccount()) {


### PR DESCRIPTION
if authenticating with LDAP. This way clients won't get confused by the reset password feature. Plus we don't want clients using any other email than their issued organization email.

This updates assumes the use of the auth-ldap plugin. A future enhancement might be to allow admins to disable profile updates for clients or agents regardless of authentication backend.
